### PR TITLE
Namespace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Some examples based on a 3 paragraph long Lorum ipsum text.
 ### Basic usage
 
 ```php
-$snippet = new TextSnippet()
+$snippet = new Swis\TextSnippet\TextSnippet();
 $snippet->createSnippet('Lorem', $lorumIpsum);
 ```
 
@@ -29,13 +29,27 @@ Will result in:
 **Lorem** ipsum dolor sit amet, consectetur adipiscing elit. ... Etiam bibendum **lorem** nec tempus sollicitudin. ... Sed in dapibus **lorem**. ... Nunc turpis ipsum, bibendum quis sodales sed, ullamcorper et **lorem**. Donec et metus hendrerit, interdum elit ut, dignissim dui.
 
 
+### For Laravel
+
+Add the source location to ``composer.json`` which adds the package to the composer autoload collection:
+```
+"autoload": {
+    "psr-4": {
+        "App\\": "app/", 
+        "Swis\\TextSnippet\\": "vendor/swisnl/textsnippet/src/"
+    }
+}
+```
+And run ``composer dump-autoload``
+
+
 ### Setting highlight html
 
 You can set the tags surrounding the highlighted text. The `%word%` tag is required.
 
 ```php
-$snippet = new TextSnippet()
-$snippet->setHighlightTemplate('<strong>%word%</strong>')
+$snippet = new Swis\TextSnippet\TextSnippet();
+$snippet->setHighlightTemplate('<strong>%word%</strong>');
 ```
 
 ### Setting min and max words
@@ -51,7 +65,7 @@ $maxWords = 100;
 Setting min and max words.
 
 ```php
-$snippet = new TextSnippet()
+$snippet = new Swis\TextSnippet\TextSnippet();
 $snippet->setMinWords(10);
 $snippet->setMaxWords(30);
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Swis\\": "src/"
+			"Swis\\TextSnippet\\": "src/"
 		}
 	},
 	"autoload-dev": {

--- a/src/TextSnippet.php
+++ b/src/TextSnippet.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Swis;
+namespace Swis\TextSnippet;
 
 class TextSnippet
 {

--- a/tests/TextSnippetTest.php
+++ b/tests/TextSnippetTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Swis\TextSnippet\Tests;
 
 
 use PHPUnit\Framework\TestCase;
-use Swis\TextSnippet;
+use Swis\TextSnippet\TextSnippet;
 
 /**
  * @backupStaticAttributes disabled


### PR DESCRIPTION
To enable the requirement of the package to frameworks like Laravel, the namespaces have to match the psr-4 requirements.

Additionally, in the readme file, a explanation is given on how to import the source file to composer autoload. This should work for any framework. Not only Laravel.